### PR TITLE
Configure Renovate to auto-merge minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended"
   ],
-  "automerge": true,
+  "automerge": false,
   "automergeType": "pr",
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "automerge": true,
+  "automergeType": "pr",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ],
+  "platformAutomerge": true
 }


### PR DESCRIPTION
## Summary
- Enable automatic merging for minor and patch dependency updates when CI passes
- Keep major updates manual for review to ensure breaking changes are properly handled
- Use platform automerge feature for better GitHub integration

## Changes
- Added `automerge: true` to enable the automerge feature
- Set `automergeType: "pr"` to use pull request merging
- Added package rules to automatically merge minor and patch updates
- Explicitly disabled automerge for major updates
- Enabled `platformAutomerge` for native GitHub automerge support

## Test plan
- [ ] Verify Renovate bot recognizes the new configuration
- [ ] Confirm that minor/patch PRs from Renovate show automerge enabled
- [ ] Ensure major version PRs still require manual review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update management by enabling conditional auto-merging of updates based on their type (minor, patch, or major).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->